### PR TITLE
fix-42-logging

### DIFF
--- a/src/core/apps.py
+++ b/src/core/apps.py
@@ -1,6 +1,42 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.urls import reverse
 
 
 class CoreConfig(AppConfig):
-    name = "core"
+    name = 'core'
     verbose_name = 'Общие утилиты проекта'
+
+    def ready(self):
+        self._log_startup_message()
+
+    @staticmethod
+    def _log_startup_message() -> None:
+        """
+        Logs a message indicating the successful startup of the project.
+
+        Configures the logger using the settings defined in `settings.LOGGING` and logs an informational message
+        containing a URL where the system status can be checked. If an error occurs while forming the URL or during
+        logging, it logs the error message.
+
+        :rtype: None
+
+        :raises Exception: Logs any exception that occurs during URL formation or logging.
+        """
+
+        import logging.config
+
+        logging_conf = settings.LOGGING
+        logging.config.dictConfig(logging_conf)
+        logger = logging.getLogger(__name__)
+
+        try:
+            url_path = reverse('check_logs')
+            # TODO: Replace 'http://localhost:8000'
+            base_url = 'http://localhost:8000'
+            full_url = f'{base_url}{url_path}'
+
+            logger.info(f'Проект запущен успешно. Вы можете проверить работу системы по данной ссылке: {full_url}')
+
+        except Exception as e:
+            logger.error(f'Ошибка при формировании сообщения о запуске: {e}')

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from .views.check_system import CheckLogs
 
+
 urlpatterns = [
     path('check-logs/', CheckLogs.as_view(), name='check_logs'),
 ]

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .views.check_system import CheckLog
+from .views.check_system import CheckLogs
 
 urlpatterns = [
-    path('check-logs/', CheckLog.as_view(), name='check_logs'),
+    path('check-logs/', CheckLogs.as_view(), name='check_logs'),
 ]

--- a/src/core/views/check_system.py
+++ b/src/core/views/check_system.py
@@ -1,8 +1,19 @@
 from django.http import JsonResponse
+from django.conf import settings
 from rest_framework.views import APIView
 
 
 class CheckSystem(APIView):
     def get(self, request):
         data = {'message': 'Hello, World!'}
+        return JsonResponse(data)
+
+
+class CheckLogs(APIView):
+    def get(self, request):
+        from settings.logging import example_logs, LOGGING
+
+        data = {'message': 'Check logs'}
+
+        example_logs(LOGGING)
         return JsonResponse(data)

--- a/src/core/views/check_system.py
+++ b/src/core/views/check_system.py
@@ -1,5 +1,4 @@
 from django.http import JsonResponse
-from django.conf import settings
 from rest_framework.views import APIView
 
 
@@ -15,5 +14,5 @@ class CheckLogs(APIView):
 
         data = {'message': 'Check logs'}
 
-        example_logs(LOGGING)
+        example_logs()
         return JsonResponse(data)

--- a/src/settings/logging.py
+++ b/src/settings/logging.py
@@ -19,7 +19,7 @@ LOGGING = {
 
     'formatters': {
         'custom': {
-            'format': '{levelname} - {asctime} - {module} - {message}',
+            'format': '{levelname} - {asctime} - {pathname}:{lineno} - {funcName}() - {message}',
             'style': '{',
         },
     },
@@ -61,8 +61,7 @@ def example_logs(logging_conf: dict) -> None:
 
     :raises ImportError: If the logging.config module could not be imported.
     :raises KeyError: If a required key is missing from the logging configuration.
-    :raises Exception: To handle any other exceptions that may occur during setting up or using
-    logging.
+    :raises Exception: To handle any other exceptions that may occur during setting up or using logging.
     """
 
     try:
@@ -84,6 +83,3 @@ def example_logs(logging_conf: dict) -> None:
         print(f'Logging configuration error: missing key {e}')
     except Exception as e:
         print(f'An error occurred while setting up logging: {e}')
-
-
-example_logs(LOGGING)

--- a/src/settings/logging.py
+++ b/src/settings/logging.py
@@ -47,7 +47,7 @@ LOGGING = {
 }
 
 
-def example_logs(logging_conf: dict) -> None:
+def example_logs(logging_conf: dict = LOGGING) -> None:
     """
     Processes examples of logs of different levels.
 


### PR DESCRIPTION
Изменен формат логов: вместо имени модуля выводятся путь к нему, строка, имя функции.

Не понял, какая ссылка должна быть в: 'Вы можете проверить работу системы по данной ссылке:', поэтому там сейчас ссылка на CheckLogs.as_view().

Readme пока не трогал, переделаю, когда окончательно утвердим систему логов.